### PR TITLE
Set up domain records to use custom root domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# 📜 From https://raw.githubusercontent.com/github/gitignore/master/Terraform.gitignore
+# (2021-03-25)
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/linode/linode" {
+  version     = "1.16.0"
+  constraints = "1.16.0"
+  hashes = [
+    "h1:Fdep/ol4g9x+9TrYYd8RNTTEQop8K3gwWM2DhBWyR7U=",
+    "zh:03c867440797b82012cd5d97f58fef5885dc0248683227299a39af836df222db",
+    "zh:0486be7f72d6ea73d10140e23be8c1d2772b2d8be28c7bb39c73be83601405cf",
+    "zh:181929d6880cac6500f4af1f3799385c47ccd69872cacf1042a3a48e445b2b02",
+    "zh:18b7f6cc1ddf86e28322638607e1f84c1e9d56824c26903e22d4d12352f20b6e",
+    "zh:4e65e7f9e17c334ff7047fc2dd8fc479c2509cba66834d89e2033a45e9275fe3",
+    "zh:6077eda3fdf77a5158d9dc1a0c38492e23f7d679b1ac96382ba92ebe92e19266",
+    "zh:642e7c96867c519176d84228a7f9104352212ae3c999b409eee1076b7ed90a96",
+    "zh:6451f5117125fad9884214fe2f2635a2bed95912e64cf1c66a57c38558dfe907",
+    "zh:83b957b30da19586393b9aea2cc93524a7d4c43dd07d11129a11d29c2b4bfb21",
+    "zh:852954fe6cfe5278bd7c3d1079a9832bbf8c58436486489ed85154c0a0600633",
+    "zh:a2385c51147a3c40707f7bfceb673c077e1054e8af6fb4c808cef56f995b8193",
+    "zh:d21cd5cb5a635d18547430fe6cdfe3c6898541f9f3adc110edbf8d6e0439390d",
+  ]
+}

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "terraform"

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1,0 +1,45 @@
+{
+  "entries": {
+    "brew": {
+      "terraform": {
+        "version": "0.14.9",
+        "bottle": {
+          "rebuild": 0,
+          "cellar": ":any_skip_relocation",
+          "prefix": "/usr/local",
+          "root_url": "https://homebrew.bintray.com/bottles",
+          "files": {
+            "arm64_big_sur": {
+              "url": "https://homebrew.bintray.com/bottles/terraform-0.14.9.arm64_big_sur.bottle.tar.gz",
+              "sha256": "9fa4f41a5a7e06d333360a115aa9522c7c9bf2af1d084c1fda97afe5bb42b6b5"
+            },
+            "big_sur": {
+              "url": "https://homebrew.bintray.com/bottles/terraform-0.14.9.big_sur.bottle.tar.gz",
+              "sha256": "dfd5c5743fdc5673306af64c8e0e90f772cbba9894c8dfd9e5db997d78701c51"
+            },
+            "catalina": {
+              "url": "https://homebrew.bintray.com/bottles/terraform-0.14.9.catalina.bottle.tar.gz",
+              "sha256": "13569fb0d2ca22be30ba47cd1b174d991fb2066a76b66f63d5fee7cad0c3adcc"
+            },
+            "mojave": {
+              "url": "https://homebrew.bintray.com/bottles/terraform-0.14.9.mojave.bottle.tar.gz",
+              "sha256": "bfee3798e84bbb0015f294643e1cba328dac8584501610c948d65f46cba83b32"
+            }
+          }
+        }
+      }
+    }
+  },
+  "system": {
+    "macos": {
+      "big_sur": {
+        "HOMEBREW_VERSION": "3.0.9-23-g04d1142",
+        "HOMEBREW_PREFIX": "/usr/local",
+        "Homebrew/homebrew-core": "ac67857cca9b250d29aa8b8ca95d6b6a27bc9c04",
+        "CLT": "12.4.0.0.1.1610135815",
+        "Xcode": "12.4",
+        "macOS": "11.2.3"
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+install:  ## Install Brew dependencies
+	brew bundle

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    linode = {
+      source = "linode/linode"
+      version = "1.16.0"
+    }
+  }
+}
+
+provider "linode" {
+  # Configuration options
+}

--- a/statium.tf
+++ b/statium.tf
@@ -1,0 +1,30 @@
+resource "linode_domain" "statium" {
+    domain = "statium.io"
+    type = "master"
+    soa_email = "example@foobar.example"
+}
+
+# 📜 https://docs.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
+resource "linode_domain_record" "statium_github_pages_1" {
+    domain_id = linode_domain.statium.id
+    record_type = "A"
+    target = "185.199.108.153"
+}
+
+resource "linode_domain_record" "statium_github_pages_2" {
+    domain_id = linode_domain.statium.id
+    record_type = "A"
+    target = "185.199.109.153"
+}
+
+resource "linode_domain_record" "statium_github_pages_3" {
+    domain_id = linode_domain.statium.id
+    record_type = "A"
+    target = "185.199.110.153"
+}
+
+resource "linode_domain_record" "statium_github_pages_4" {
+    domain_id = linode_domain.statium.id
+    record_type = "A"
+    target = "185.199.111.153"
+}


### PR DESCRIPTION
This PR configures the `statium.io` domain and its records on Linode so that https://github.com/statium-io/statium-webapp can be hosted on the root domain. I used Terraform to configure this.